### PR TITLE
Fixed Aruba::SpawnProcess message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+# Added these files to not force others to use them.
+.overcommit.yml
+.rvmrc

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This is just a little sample command-line app that hits a web service. 
 
 It exists to accompany a [blog post](http://georgemcintosh.com/vcr-and-aruba/) on testing Ruby command line apps with Aruba and VCR.
+
+NOTE: To run the tests/specs, type "cucumber" on the command line.

--- a/advice.gemspec
+++ b/advice.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 require 'aruba/cucumber'
 require 'aruba/in_process'
+require 'aruba/spawn_process'
 require 'vcr'
 require 'webmock'
 require 'advice'


### PR DESCRIPTION
Added "require 'aruba/spawn_process'" to  features/support/env.rb
to fix the "uninitialized constant Aruba::SpawnProcess (NameError)"
error during cucumber run.